### PR TITLE
Implemented associative labels

### DIFF
--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -15,6 +15,7 @@ class CustomForm extends Form {
 	private $data = [];
 	/** @var string */
 	public $playerName;
+	private $labelMap = [];
 
 	/**
 	 * @param int $id
@@ -45,6 +46,16 @@ class CustomForm extends Form {
 		$this->playerName = $player->getName();
 	}
 
+	public function processData(&$data) : void {
+		if(is_array($data)){
+			$new = [];
+			foreach($data as $i => $v){
+				$new[$this->labelMap[$i]] = $v;
+			}
+			$data = $new;
+		}
+	}
+
 	/**
 	 * @param string $title
 	 */
@@ -61,21 +72,25 @@ class CustomForm extends Form {
 
 	/**
 	 * @param string $text
+	 * @param string|null $label
 	 */
-	public function addLabel(string $text) : void {
+	public function addLabel(string $text, ?string $label = null) : void {
 		$this->addContent(["type" => "label", "text" => $text]);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**
 	 * @param string $text
 	 * @param bool|null $default
+	 * @param string|null $label
 	 */
-	public function addToggle(string $text, bool $default = null) : void {
+	public function addToggle(string $text, bool $default = null, ?string $label = null) : void {
 		$content = ["type" => "toggle", "text" => $text];
 		if($default !== null){
 			$content["default"] = $default;
 		}
 		$this->addContent($content);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**
@@ -84,8 +99,9 @@ class CustomForm extends Form {
 	 * @param int $max
 	 * @param int $step
 	 * @param int $default
+	 * @param string|null $label
 	 */
-	public function addSlider(string $text, int $min, int $max, int $step = -1, int $default = -1) : void {
+	public function addSlider(string $text, int $min, int $max, int $step = -1, int $default = -1, ?string $label = null) : void {
 		$content = ["type" => "slider", "text" => $text, "min" => $min, "max" => $max];
 		if($step !== -1){
 			$content["step"] = $step;
@@ -94,37 +110,44 @@ class CustomForm extends Form {
 			$content["default"] = $default;
 		}
 		$this->addContent($content);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**
 	 * @param string $text
 	 * @param array $steps
 	 * @param int $defaultIndex
+	 * @param string|null $label
 	 */
-	public function addStepSlider(string $text, array $steps, int $defaultIndex = -1) : void {
+	public function addStepSlider(string $text, array $steps, int $defaultIndex = -1, ?string $label = null) : void {
 		$content = ["type" => "step_slider", "text" => $text, "steps" => $steps];
 		if($defaultIndex !== -1){
 			$content["default"] = $defaultIndex;
 		}
 		$this->addContent($content);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**
 	 * @param string $text
 	 * @param array $options
 	 * @param int $default
+	 * @param string|null $label
 	 */
-	public function addDropdown(string $text, array $options, int $default = null) : void {
+	public function addDropdown(string $text, array $options, int $default = null, ?string $label = null) : void {
 		$this->addContent(["type" => "dropdown", "text" => $text, "options" => $options, "default" => $default]);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**
 	 * @param string $text
 	 * @param string $placeholder
 	 * @param string $default
+	 * @param string|null $label
 	 */
-	public function addInput(string $text, string $placeholder = "", string $default = null) : void {
+	public function addInput(string $text, string $placeholder = "", string $default = null, ?string $label = null) : void {
 		$this->addContent(["type" => "input", "text" => $text, "placeholder" => $placeholder, "default" => $default]);
+		$this->labelMap[] = $label ?? count($this->labelMap);
 	}
 
 	/**

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -53,4 +53,6 @@ abstract class Form {
 		return $this->callable;
 	}
 
+	public function processData(&$data) : void {
+	}
 }

--- a/src/jojoe77777/FormAPI/FormAPI.php
+++ b/src/jojoe77777/FormAPI/FormAPI.php
@@ -75,6 +75,7 @@ class FormAPI extends PluginBase implements Listener {
 				if(!$form->isRecipient($player)){
 					return;
 				}
+				$form->processData($data);
 				$callable = $form->getCallable();
 				if(!is_array($data)){
 					$data = [$data];


### PR DESCRIPTION
This pull request is fully backward-compatible.
If developers pass an extra string while adding a component, the element data's key in the response data array will be changed to this string. Otherwise, it will not be changed, and will keep using the auto-incremental number.

I'm not very sure about how you are handling $data. Why did you convert `$data` into an array if it isn't one? So if the form is just closed rather than submitted, would it be a form containing a null?