### PR TITLE
Fix PC packet

### DIFF
--- a/src/jojoe77777/FormAPI/FormAPI.php
+++ b/src/jojoe77777/FormAPI/FormAPI.php
@@ -62,7 +62,11 @@ class FormAPI extends PluginBase implements Listener {
         if($pk instanceof ModalFormResponsePacket) {
             $player = $ev->getPlayer();
             $formId = $pk->formId;
-            $data = json_decode($pk->formData, true);
+            
+            $fix = str_replace([',,', ',]'], [',"",', ',""]'], $pk->formData);
+            $data = json_decode($fix, true);
+            #$data = json_decode($pk->formData, true);
+            
             if(isset($this->forms[$formId])) {
                 /** @var Form $form */
                 $form = $this->forms[$formId];


### PR DESCRIPTION
Since "" "is not included in JSON sent from the PC version form, it is NULL in json_decode. It is a fix to prevent it.

formData
- PC: "[,0,,]"  ->json_decode->  NULL
- Mobile: "["",0,"",""]"  ->json_decode->  array(0 => "", 1 => 0, 2 => "", 3 => "")