### PR TITLE
Prepare for PocketMine-MP 3.2.0, use new API

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: FormAPI
 main: jojoe77777\FormAPI\FormAPI
 version: 1.2.0
-api: [3.2.0]
+api: 3.2.0
 author: jojoe77777

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: FormAPI
 main: jojoe77777\FormAPI\FormAPI
 version: 1.2.0
-api: [3.0.0]
+api: [3.2.0]
 author: jojoe77777

--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -4,46 +4,18 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
-use pocketmine\Player;
-
 class CustomForm extends Form {
 
-    /** @var int */
-    public $id;
-    /** @var array */
-    private $data = [];
-    /** @var string */
-    public $playerName;
     private $labelMap = [];
 
     /**
-     * @param int $id
      * @param callable $callable
      */
-    public function __construct(int $id, ?callable $callable) {
-        parent::__construct($id, $callable);
+    public function __construct(?callable $callable) {
+        parent::__construct($callable);
         $this->data["type"] = "custom_form";
         $this->data["title"] = "";
         $this->data["content"] = [];
-    }
-
-    /**
-     * @return int
-     */
-    public function getId() : int {
-        return $this->id;
-    }
-
-    /**
-     * @param Player $player
-     */
-    public function sendToPlayer(Player $player) : void {
-        $pk = new ModalFormRequestPacket();
-        $pk->formId = $this->id;
-        $pk->formData = json_encode($this->data);
-        $player->dataPacket($pk);
-        $this->playerName = $player->getName();
     }
 
     public function processData(&$data) : void {

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -4,49 +4,31 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
+use pocketmine\form\Form as IForm;
 use pocketmine\Player;
 
-abstract class Form {
+abstract class Form implements IForm{
 
-    /** @var int */
-    public $id;
     /** @var array */
-    private $data = [];
-    /** @var string */
-    public $playerName;
+    protected $data = [];
     /** @var callable */
     private $callable;
 
     /**
-     * @param int $id
      * @param callable $callable
      */
-    public function __construct(int $id, ?callable $callable) {
-        $this->id = $id;
+    public function __construct(?callable $callable) {
         $this->callable = $callable;
     }
 
     /**
-     * @return int
-     */
-    public function getId() : int {
-        return $this->id;
-    }
-
-    /**
+     * @deprecated
+     * @see Player::sendForm()
+     *
      * @param Player $player
      */
     public function sendToPlayer(Player $player) : void {
-        $pk = new ModalFormRequestPacket();
-        $pk->formId = $this->id;
-        $pk->formData = json_encode($this->data);
-        $player->dataPacket($pk);
-        $this->playerName = $player->getName();
-    }
-
-    public function isRecipient(Player $player) : bool {
-        return $player->getName() === $this->playerName;
+        $player->sendForm($this);
     }
 
     public function getCallable() : ?callable {
@@ -57,6 +39,19 @@ abstract class Form {
         $this->callable = $callable;
     }
 
+    public function handleResponse(Player $player, $data) : ?IForm{
+        $this->processData($data);
+        $callable = $this->getCallable();
+        if($callable !== null) {
+            $callable($player, $data);
+        }
+        return null;
+    }
+
     public function processData(&$data) : void {
+    }
+
+    public function jsonSerialize(){
+        return $this->data;
     }
 }

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -39,13 +39,12 @@ abstract class Form implements IForm{
         $this->callable = $callable;
     }
 
-    public function handleResponse(Player $player, $data) : ?IForm{
+    public function handleResponse(Player $player, $data) : void {
         $this->processData($data);
         $callable = $this->getCallable();
         if($callable !== null) {
             $callable($player, $data);
         }
-        return null;
     }
 
     public function processData(&$data) : void {

--- a/src/jojoe77777/FormAPI/FormAPI.php
+++ b/src/jojoe77777/FormAPI/FormAPI.php
@@ -4,97 +4,37 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
-use pocketmine\event\Listener;
-use pocketmine\event\player\PlayerQuitEvent;
-use pocketmine\event\server\DataPacketReceiveEvent;
-use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
 use pocketmine\plugin\PluginBase;
 
-class FormAPI extends PluginBase implements Listener {
-
-    /** @var int */
-    public $formCount = 0;
-    /** @var array */
-    public $forms = [];
-
-    public function onEnable() : void {
-        $this->formCount = rand(0, 0xFFFFFFFF);
-        $this->getServer()->getPluginManager()->registerEvents($this, $this);
-    }
+class FormAPI extends PluginBase{
 
     /**
+     * @deprecated
+     *
      * @param callable $function
      * @return CustomForm
      */
     public function createCustomForm(callable $function = null) : CustomForm {
-        $this->formCountBump();
-        $form = new CustomForm($this->formCount, $function);
-        $this->forms[$this->formCount] = $form;
-        return $form;
+        return new CustomForm($function);
     }
 
+    /**
+     * @deprecated
+     *
+     * @param callable|null $function
+     * @return SimpleForm
+     */
     public function createSimpleForm(callable $function = null) : SimpleForm {
-        $this->formCountBump();
-        $form = new SimpleForm($this->formCount, $function);
-        $this->forms[$this->formCount] = $form;
-        return $form;
+        return new SimpleForm($function);
     }
 
+    /**
+     * @deprecated
+     *
+     * @param callable|null $function
+     * @return ModalForm
+     */
     public function createModalForm(callable $function = null) : ModalForm {
-        $this->formCountBump();
-        $form = new ModalForm($this->formCount, $function);
-        $this->forms[$this->formCount] = $form;
-        return $form;
+        return new ModalForm($function);
     }
-
-    public function formCountBump() : void {
-        ++$this->formCount;
-        if($this->formCount & (1 << 32)) { // integer overflow!
-            $this->formCount = rand(0, 0xFFFFFFFF);
-        }
-    }
-
-    /**
-     * @param DataPacketReceiveEvent $ev
-     */
-    public function onPacketReceived(DataPacketReceiveEvent $ev) : void {
-        $pk = $ev->getPacket();
-        if($pk instanceof ModalFormResponsePacket) {
-            $player = $ev->getPlayer();
-            $formId = $pk->formId;
-            $data = json_decode($pk->formData, true);
-            if(isset($this->forms[$formId])) {
-                /** @var Form $form */
-                $form = $this->forms[$formId];
-                if(!$form->isRecipient($player)) {
-                    return;
-                }
-                $form->processData($data);
-                $callable = $form->getCallable();
-                if($callable !== null) {
-                    $callable($ev->getPlayer(), $data);
-                }
-                unset($this->forms[$formId]);
-                $ev->setCancelled();
-            }
-        }
-    }
-
-    /**
-     * @param PlayerQuitEvent $ev
-     */
-    public function onPlayerQuit(PlayerQuitEvent $ev) {
-        $player = $ev->getPlayer();
-        /**
-         * @var int $id
-         * @var Form $form
-         */
-        foreach ($this->forms as $id => $form) {
-            if($form->isRecipient($player)) {
-                unset($this->forms[$id]);
-                break;
-            }
-        }
-    }
-
 }

--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -4,49 +4,21 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
-use pocketmine\Player;
-
 class ModalForm extends Form {
 
-    /** @var int */
-    public $id;
-    /** @var array */
-    private $data = [];
     /** @var string */
     private $content = "";
-    /** @var string */
-    public $playerName;
 
     /**
-     * @param int $id
      * @param callable $callable
      */
-    public function __construct(int $id, ?callable $callable) {
-        parent::__construct($id, $callable);
+    public function __construct(?callable $callable) {
+        parent::__construct($callable);
         $this->data["type"] = "modal";
         $this->data["title"] = "";
         $this->data["content"] = $this->content;
         $this->data["button1"] = "";
         $this->data["button2"] = "";
-    }
-
-    /**
-     * @return int
-     */
-    public function getId() : int {
-        return $this->id;
-    }
-
-    /**
-     * @param Player $player
-     */
-    public function sendToPlayer(Player $player) : void {
-        $pk = new ModalFormRequestPacket();
-        $pk->formId = $this->id;
-        $pk->formData = json_encode($this->data);
-        $player->dataPacket($pk);
-        $this->playerName = $player->getName();
     }
 
     /**

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -4,51 +4,24 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
-use pocketmine\network\mcpe\protocol\ModalFormRequestPacket;
-use pocketmine\Player;
-
 class SimpleForm extends Form {
 
     const IMAGE_TYPE_PATH = 0;
     const IMAGE_TYPE_URL = 1;
 
-    /** @var int */
-    public $id;
-    /** @var array */
-    private $data = [];
     /** @var string */
     private $content = "";
-    /** @var string */
-    public $playerName;
+
     private $labelMap = [];
 
     /**
-     * @param int $id
      * @param callable $callable
      */
-    public function __construct(int $id, ?callable $callable) {
-        parent::__construct($id, $callable);
+    public function __construct(?callable $callable) {
+        parent::__construct($callable);
         $this->data["type"] = "form";
         $this->data["title"] = "";
         $this->data["content"] = $this->content;
-    }
-
-    /**
-     * @return int
-     */
-    public function getId() : int {
-        return $this->id;
-    }
-
-    /**
-     * @param Player $player
-     */
-    public function sendToPlayer(Player $player) : void {
-        $pk = new ModalFormRequestPacket();
-        $pk->formId = $this->id;
-        $pk->formData = json_encode($this->data);
-        $player->dataPacket($pk);
-        $this->playerName = $player->getName();
     }
 
     public function processData(&$data) : void {


### PR DESCRIPTION
_THIS IS NOT READY FOR MERGING YET_

This nukes most of the plugin. This could later be transformed into a library instead of a plugin since it doesn't need any event listeners anymore.

The following methods have been removed:
`Form->getId()`
`Form->isRecipient()`

The following methods have been deprecated:
`FormAPI->createSimpleForm()`
`FormAPI->createModalForm()`
`FormAPI->createCustomForm()`
`Form->sendToPlayer()`

The constructors of all `Form` types no longer accept `$id` parameters.