### PR TITLE
Match PhpDocs to paramaters

### DIFF
--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -9,7 +9,7 @@ class CustomForm extends Form {
     private $labelMap = [];
 
     /**
-     * @param callable $callable
+     * @param callable|null $callable
      */
     public function __construct(?callable $callable) {
         parent::__construct($callable);

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -11,11 +11,11 @@ abstract class Form implements IForm{
 
     /** @var array */
     protected $data = [];
-    /** @var callable */
+    /** @var callable|null */
     private $callable;
 
     /**
-     * @param callable $callable
+     * @param callable|null $callable
      */
     public function __construct(?callable $callable) {
         $this->callable = $callable;

--- a/src/jojoe77777/FormAPI/FormAPI.php
+++ b/src/jojoe77777/FormAPI/FormAPI.php
@@ -11,10 +11,10 @@ class FormAPI extends PluginBase{
     /**
      * @deprecated
      *
-     * @param callable $function
+     * @param callable|null $function
      * @return CustomForm
      */
-    public function createCustomForm(callable $function = null) : CustomForm {
+    public function createCustomForm(?callable $function = null) : CustomForm {
         return new CustomForm($function);
     }
 
@@ -24,7 +24,7 @@ class FormAPI extends PluginBase{
      * @param callable|null $function
      * @return SimpleForm
      */
-    public function createSimpleForm(callable $function = null) : SimpleForm {
+    public function createSimpleForm(?callable $function = null) : SimpleForm {
         return new SimpleForm($function);
     }
 
@@ -34,7 +34,7 @@ class FormAPI extends PluginBase{
      * @param callable|null $function
      * @return ModalForm
      */
-    public function createModalForm(callable $function = null) : ModalForm {
+    public function createModalForm(?callable $function = null) : ModalForm {
         return new ModalForm($function);
     }
 }

--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -10,7 +10,7 @@ class ModalForm extends Form {
     private $content = "";
 
     /**
-     * @param callable $callable
+     * @param callable|null $callable
      */
     public function __construct(?callable $callable) {
         parent::__construct($callable);

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -15,7 +15,7 @@ class SimpleForm extends Form {
     private $labelMap = [];
 
     /**
-     * @param callable $callable
+     * @param callable|null $callable
      */
     public function __construct(?callable $callable) {
         parent::__construct($callable);


### PR DESCRIPTION
PhpStorm continues bothering me every time I leave a constructor with null even though it is allowed. This PR fixes the incorrect PhpDocs causing the given annoyances.