### PR TITLE
Removed the deprecated sendToPlayer() method

### DIFF
--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -21,16 +21,6 @@ abstract class Form implements IForm{
         $this->callable = $callable;
     }
 
-    /**
-     * @deprecated
-     * @see Player::sendForm()
-     *
-     * @param Player $player
-     */
-    public function sendToPlayer(Player $player) : void {
-        $player->sendForm($this);
-    }
-
     public function getCallable() : ?callable {
         return $this->callable;
     }


### PR DESCRIPTION
Since this method is deprecated, why not just remove it?