### PR TITLE
SimpleForm: Allow mixed value on labels

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,6 +1,6 @@
---- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/jojoe77777/FormAPI
+--- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/IvanCraft623/FormAPI
 branches:
-- master
+- stable
 projects:
   FormAPI:
     path: ""

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,6 +1,6 @@
---- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/IvanCraft623/FormAPI
+--- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/jojoe77777/FormAPI
 branches:
-- stable
+- master
 projects:
   FormAPI:
     path: ""

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -72,9 +72,9 @@ class SimpleForm extends Form {
      * @param string $text
      * @param int $imageType
      * @param string $imagePath
-     * @param string $label
+     * @param mixed $label
      */
-    public function addButton(string $text, int $imageType = -1, string $imagePath = "", ?string $label = null) : void {
+    public function addButton(string $text, int $imageType = -1, string $imagePath = "", mixed $label = null) : void {
         $content = ["text" => $text];
         if($imageType !== -1) {
             $content["image"]["type"] = $imageType === 0 ? "path" : "url";


### PR DESCRIPTION
## Introduction
This pull request will remove the limit for plugin developers to only set strings as labels.

## Justification
In some cases, for example when the button references an object, it is necessary to make hacky or inefficient code to achieve the goal.

Example: A teleport form
### Before:
```php
$form = new SimpleForm(function (Player $player, ?string $result = null) {
	if ($result !== null) {
		$pl = $player->getServer()->getPlayerExact($result);
		if ($pl !== null) {
			$player->teleport($pl->getPosition());
		}
	}
});
$form->setTitle("Teleporter");
$form->setContent("Teleport you to another player position");
foreach ($player->getWorld()->getPlayers() as $pl) {
	$form->addButton($pl->getName(), -1, "", $pl->getName());
}
$form->sendToPlayer($player);
```
### After:
```php
$form = new SimpleForm(function (Player $player, ?Player $result = null) {
	if ($result !== null) {
		$player->teleport($result->getPosition());
	}
});
$form->setTitle("Teleporter");
$form->setContent("Teleport you to another player position");
foreach ($player->getWorld()->getPlayers() as $pl) {
	$form->addButton($pl->getName(), -1, "", $pl);
}
$form->sendToPlayer($player);
```
## Backwards compatibility
This is technically BC Break as it requires at least PHP8, but since PM4 already requires PHP8 as a minimum there should be no problems.