### PR TITLE
feat: add virion 3.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 .DS_Store
+
+vendor/*
+composer.lock

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This library can be loaded as a plugin phar. You can use the [`depend`](https://
 ### As a virion
 This library supports being included as a [virion](https://github.com/poggit/support/blob/master/virion.md).
 
+#### Virion v1
 If you use [Poggit](https://poggit.pmmp.io) to build your plugin, you can add it to your `.poggit.yml` like so:
 
 ```yml
@@ -17,5 +18,17 @@ projects:
   YourPlugin:
     libs:
       - src: jojoe77777/FormAPI/libFormAPI
-        version: ^2.1.1
+        version: ^2.1.0
+```
+#### Virion v3
+In your `composer.json` add an entry to the `require` attribute, like so:
+
+```diff
+  {
+    "name": "author/project",
+    "require": {
++     "jojoe77777/formapi": "^2.1.0",
+      "pmmp/pocketmine-mp": "^4.0.0
+    }
+  }
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ projects:
   YourPlugin:
     libs:
       - src: jojoe77777/FormAPI/libFormAPI
-        version: ^2.1.0
+        version: ^2.1.1
 ```
 #### Virion v3
 In your `composer.json` add an entry to the `require` attribute, like so:
@@ -27,7 +27,7 @@ In your `composer.json` add an entry to the `require` attribute, like so:
   {
     "name": "author/project",
     "require": {
-+     "jojoe77777/formapi": "^2.1.0",
++     "jojoe77777/formapi": "^2.1.1",
       "pmmp/pocketmine-mp": "^4.0.0
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "jojoe77777/formapi",
+    "description": "Simple API for creating forms on PocketMine-MP.",
+    "type": "library",
+    "license": "LGPL-3.0",
+    "require": {
+        "pocketmine/pocketmine-mp": "^4.0.0"
+    },
+    "autoload": {
+        "classmap": ["src"]
+    },
+    "authors": [
+        {
+            "name": "jojoe77777",
+            "email": "jojoefivesevens@gmail.com"
+        },
+        {
+            "name": "Dylan K. Taylor",
+            "email": "dktapps@pmmp.io"
+        }
+    ],
+    "extra": {
+        "virion": {
+            "spec": "3.0",
+            "namespace-root": "jojoe77777\\FormAPI"
+        }
+    }
+}


### PR DESCRIPTION
Hi! After merging this pull request, your users may use Virion 3.0 in their plugins by using `vcs` dependencies in their composer.json, but you could make their lives easier by completing these steps:

1. Tag each release with the `git tag` command or the [GitHub web UI](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
2. Submit your package on Packagist: https://packagist.org/packages/submit

Please follow these steps every time you release a new stable version so that user plugins can get their dependencies updated automatically upon the next build.