### PR TITLE
ModalForm's data can actually be null

### DIFF
--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -24,8 +24,10 @@ class ModalForm extends Form {
     }
 
     public function processData(&$data) : void {
-        if(!is_bool($data)) {
-            throw new FormValidationException("Expected a boolean response, got " . gettype($data));
+        if($data !== null) {
+            if(!is_bool($data)) {
+                throw new FormValidationException("Expected a boolean response, got " . gettype($data));
+            }
         }
     }
 


### PR DESCRIPTION
Player can just use escape key to close it without touching any buttons