### PR TITLE
Change setters to fluent setters and modernize code

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,7 +1,6 @@
 --- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/jojoe77777/FormAPI
 branches:
 - master
-- pm4
 projects:
   FormAPI:
     path: ""

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -1,6 +1,7 @@
 --- # Poggit-CI Manifest. Open the CI at https://poggit.pmmp.io/ci/jojoe77777/FormAPI
 branches:
 - master
+- pm4
 projects:
   FormAPI:
     path: ""

--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -46,9 +46,11 @@ class CustomForm extends Form {
 
     /**
      * @param string $title
+     * @return CustomForm
      */
-    public function setTitle(string $title) : void {
+    public function setTitle(string $title) : self {
         $this->data["title"] = $title;
+        return $this;
     }
 
     /**
@@ -61,19 +63,22 @@ class CustomForm extends Form {
     /**
      * @param string $text
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addLabel(string $text, ?string $label = null) : void {
+    public function addLabel(string $text, ?string $label = null) : self {
         $this->addContent(["type" => "label", "text" => $text]);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => $v === null;
+        return $this;
     }
 
     /**
      * @param string $text
      * @param bool|null $default
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addToggle(string $text, bool $default = null, ?string $label = null) : void {
+    public function addToggle(string $text, bool $default = null, ?string $label = null) : self {
         $content = ["type" => "toggle", "text" => $text];
         if($default !== null) {
             $content["default"] = $default;
@@ -81,6 +86,7 @@ class CustomForm extends Form {
         $this->addContent($content);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => is_bool($v);
+        return $this;
     }
 
     /**
@@ -90,8 +96,9 @@ class CustomForm extends Form {
      * @param int $step
      * @param int $default
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addSlider(string $text, int $min, int $max, int $step = -1, int $default = -1, ?string $label = null) : void {
+    public function addSlider(string $text, int $min, int $max, int $step = -1, int $default = -1, ?string $label = null) : self {
         $content = ["type" => "slider", "text" => $text, "min" => $min, "max" => $max];
         if($step !== -1) {
             $content["step"] = $step;
@@ -102,6 +109,7 @@ class CustomForm extends Form {
         $this->addContent($content);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => (is_float($v) || is_int($v)) && $v >= $min && $v <= $max;
+        return $this;
     }
 
     /**
@@ -109,8 +117,9 @@ class CustomForm extends Form {
      * @param array $steps
      * @param int $defaultIndex
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addStepSlider(string $text, array $steps, int $defaultIndex = -1, ?string $label = null) : void {
+    public function addStepSlider(string $text, array $steps, int $defaultIndex = -1, ?string $label = null) : self {
         $content = ["type" => "step_slider", "text" => $text, "steps" => $steps];
         if($defaultIndex !== -1) {
             $content["default"] = $defaultIndex;
@@ -118,37 +127,44 @@ class CustomForm extends Form {
         $this->addContent($content);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => is_int($v) && isset($steps[$v]);
+        return $this;
     }
 
     /**
      * @param string $text
      * @param array $options
-     * @param int $default
+     * @param int|null $default
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addDropdown(string $text, array $options, int $default = null, ?string $label = null) : void {
+    public function addDropdown(string $text, array $options, int $default = null, ?string $label = null) : self {
         $this->addContent(["type" => "dropdown", "text" => $text, "options" => $options, "default" => $default]);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => is_int($v) && isset($options[$v]);
+        return $this;
     }
 
     /**
      * @param string $text
      * @param string $placeholder
-     * @param string $default
+     * @param string|null $default
      * @param string|null $label
+     * @return CustomForm
      */
-    public function addInput(string $text, string $placeholder = "", string $default = null, ?string $label = null) : void {
+    public function addInput(string $text, string $placeholder = "", string $default = null, ?string $label = null) : self {
         $this->addContent(["type" => "input", "text" => $text, "placeholder" => $placeholder, "default" => $default]);
         $this->labelMap[] = $label ?? count($this->labelMap);
         $this->validationMethods[] = static fn($v) => is_string($v);
+        return $this;
     }
 
     /**
      * @param array $content
+     * @return CustomForm
      */
-    private function addContent(array $content) : void {
+    private function addContent(array $content) : self {
         $this->data["content"][] = $content;
+        return $this;
     }
 
 }

--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -8,8 +8,8 @@ use pocketmine\form\FormValidationException;
 
 class CustomForm extends Form {
 
-    private $labelMap = [];
-    private $validationMethods = [];
+    private array $labelMap = [];
+    private array $validationMethods = [];
 
     /**
      * @param callable|null $callable

--- a/src/jojoe77777/FormAPI/CustomForm.php
+++ b/src/jojoe77777/FormAPI/CustomForm.php
@@ -30,7 +30,7 @@ class CustomForm extends Form {
                 throw new FormValidationException("Expected an array response with the size " . count($this->validationMethods) . ", got " . count($data));
             }
             $new = [];
-            foreach($data as $i => $v){
+            foreach($data as $i => $v) {
                 $validationMethod = $this->validationMethods[$i] ?? null;
                 if($validationMethod === null) {
                     throw new FormValidationException("Invalid element " . $i);
@@ -46,7 +46,7 @@ class CustomForm extends Form {
 
     /**
      * @param string $title
-     * @return CustomForm
+     * @return $this
      */
     public function setTitle(string $title) : self {
         $this->data["title"] = $title;
@@ -63,7 +63,7 @@ class CustomForm extends Form {
     /**
      * @param string $text
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addLabel(string $text, ?string $label = null) : self {
         $this->addContent(["type" => "label", "text" => $text]);
@@ -76,7 +76,7 @@ class CustomForm extends Form {
      * @param string $text
      * @param bool|null $default
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addToggle(string $text, bool $default = null, ?string $label = null) : self {
         $content = ["type" => "toggle", "text" => $text];
@@ -96,7 +96,7 @@ class CustomForm extends Form {
      * @param int $step
      * @param int $default
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addSlider(string $text, int $min, int $max, int $step = -1, int $default = -1, ?string $label = null) : self {
         $content = ["type" => "slider", "text" => $text, "min" => $min, "max" => $max];
@@ -117,7 +117,7 @@ class CustomForm extends Form {
      * @param array $steps
      * @param int $defaultIndex
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addStepSlider(string $text, array $steps, int $defaultIndex = -1, ?string $label = null) : self {
         $content = ["type" => "step_slider", "text" => $text, "steps" => $steps];
@@ -135,7 +135,7 @@ class CustomForm extends Form {
      * @param array $options
      * @param int|null $default
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addDropdown(string $text, array $options, int $default = null, ?string $label = null) : self {
         $this->addContent(["type" => "dropdown", "text" => $text, "options" => $options, "default" => $default]);
@@ -149,7 +149,7 @@ class CustomForm extends Form {
      * @param string $placeholder
      * @param string|null $default
      * @param string|null $label
-     * @return CustomForm
+     * @return $this
      */
     public function addInput(string $text, string $placeholder = "", string $default = null, ?string $label = null) : self {
         $this->addContent(["type" => "input", "text" => $text, "placeholder" => $placeholder, "default" => $default]);
@@ -160,7 +160,7 @@ class CustomForm extends Form {
 
     /**
      * @param array $content
-     * @return CustomForm
+     * @return $this
      */
     private function addContent(array $content) : self {
         $this->data["content"][] = $content;

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -10,7 +10,7 @@ use pocketmine\player\Player;
 abstract class Form implements IForm{
 
     /** @var array */
-    protected $data = [];
+    protected array $data = [];
     /** @var callable|null */
     private $callable;
 

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace jojoe77777\FormAPI;
 
+use InvalidArgumentException;
 use pocketmine\form\Form as IForm;
 use pocketmine\player\Player;
 
@@ -22,10 +23,10 @@ abstract class Form implements IForm{
     }
 
     /**
+     * @param Player $player
+     * @throws InvalidArgumentException
      * @deprecated
      * @see Player::sendForm()
-     *
-     * @param Player $player
      */
     public function sendToPlayer(Player $player) : void {
         $player->sendForm($this);

--- a/src/jojoe77777/FormAPI/Form.php
+++ b/src/jojoe77777/FormAPI/Form.php
@@ -51,7 +51,7 @@ abstract class Form implements IForm{
     public function processData(&$data) : void {
     }
 
-    public function jsonSerialize() : array{
+    public function jsonSerialize() : array {
         return $this->data;
     }
 }

--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -31,9 +31,11 @@ class ModalForm extends Form {
 
     /**
      * @param string $title
+     * @return ModalForm
      */
-    public function setTitle(string $title) : void {
+    public function setTitle(string $title) : self {
         $this->data["title"] = $title;
+        return $this;
     }
 
     /**
@@ -52,16 +54,20 @@ class ModalForm extends Form {
 
     /**
      * @param string $content
+     * @return ModalForm
      */
-    public function setContent(string $content) : void {
+    public function setContent(string $content) : self {
         $this->data["content"] = $content;
+        return $this;
     }
 
     /**
      * @param string $text
+     * @return ModalForm
      */
-    public function setButton1(string $text) : void {
+    public function setButton1(string $text) : self {
         $this->data["button1"] = $text;
+        return $this;
     }
 
     /**
@@ -73,9 +79,11 @@ class ModalForm extends Form {
 
     /**
      * @param string $text
+     * @return ModalForm
      */
-    public function setButton2(string $text) : void {
+    public function setButton2(string $text) : self {
         $this->data["button2"] = $text;
+        return $this;
     }
 
     /**

--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -9,7 +9,7 @@ use pocketmine\form\FormValidationException;
 class ModalForm extends Form {
 
     /** @var string */
-    private $content = "";
+    private string $content = "";
 
     /**
      * @param callable|null $callable

--- a/src/jojoe77777/FormAPI/ModalForm.php
+++ b/src/jojoe77777/FormAPI/ModalForm.php
@@ -31,7 +31,7 @@ class ModalForm extends Form {
 
     /**
      * @param string $title
-     * @return ModalForm
+     * @return $this
      */
     public function setTitle(string $title) : self {
         $this->data["title"] = $title;
@@ -54,7 +54,7 @@ class ModalForm extends Form {
 
     /**
      * @param string $content
-     * @return ModalForm
+     * @return $this
      */
     public function setContent(string $content) : self {
         $this->data["content"] = $content;
@@ -63,7 +63,7 @@ class ModalForm extends Form {
 
     /**
      * @param string $text
-     * @return ModalForm
+     * @return $this
      */
     public function setButton1(string $text) : self {
         $this->data["button1"] = $text;
@@ -79,7 +79,7 @@ class ModalForm extends Form {
 
     /**
      * @param string $text
-     * @return ModalForm
+     * @return $this
      */
     public function setButton2(string $text) : self {
         $this->data["button2"] = $text;

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -28,7 +28,7 @@ class SimpleForm extends Form {
     }
 
     public function processData(&$data) : void {
-        if($data !== null){
+        if($data !== null) {
             if(!is_int($data)) {
                 throw new FormValidationException("Expected an integer response, got " . gettype($data));
             }
@@ -42,7 +42,7 @@ class SimpleForm extends Form {
 
     /**
      * @param string $title
-     * @return SimpleForm
+     * @return $this
      */
     public function setTitle(string $title) : self {
         $this->data["title"] = $title;
@@ -65,7 +65,7 @@ class SimpleForm extends Form {
 
     /**
      * @param string $content
-     * @return SimpleForm
+     * @return $this
      */
     public function setContent(string $content) : self {
         $this->data["content"] = $content;
@@ -77,7 +77,7 @@ class SimpleForm extends Form {
      * @param int $imageType
      * @param string $imagePath
      * @param string|null $label
-     * @return SimpleForm
+     * @return $this
      */
     public function addButton(string $text, int $imageType = -1, string $imagePath = "", ?string $label = null) : self {
         $content = ["text" => $text];

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -42,9 +42,11 @@ class SimpleForm extends Form {
 
     /**
      * @param string $title
+     * @return SimpleForm
      */
-    public function setTitle(string $title) : void {
+    public function setTitle(string $title) : self {
         $this->data["title"] = $title;
+        return $this;
     }
 
     /**
@@ -63,18 +65,21 @@ class SimpleForm extends Form {
 
     /**
      * @param string $content
+     * @return SimpleForm
      */
-    public function setContent(string $content) : void {
+    public function setContent(string $content) : self {
         $this->data["content"] = $content;
+        return $this;
     }
 
     /**
      * @param string $text
      * @param int $imageType
      * @param string $imagePath
-     * @param string $label
+     * @param string|null $label
+     * @return SimpleForm
      */
-    public function addButton(string $text, int $imageType = -1, string $imagePath = "", ?string $label = null) : void {
+    public function addButton(string $text, int $imageType = -1, string $imagePath = "", ?string $label = null) : self {
         $content = ["text" => $text];
         if($imageType !== -1) {
             $content["image"]["type"] = $imageType === 0 ? "path" : "url";
@@ -82,6 +87,7 @@ class SimpleForm extends Form {
         }
         $this->data["buttons"][] = $content;
         $this->labelMap[] = $label ?? count($this->labelMap);
+        return $this;
     }
 
 }

--- a/src/jojoe77777/FormAPI/SimpleForm.php
+++ b/src/jojoe77777/FormAPI/SimpleForm.php
@@ -12,9 +12,9 @@ class SimpleForm extends Form {
     const IMAGE_TYPE_URL = 1;
 
     /** @var string */
-    private $content = "";
+    private string $content = "";
 
-    private $labelMap = [];
+    private array $labelMap = [];
 
     /**
      * @param callable|null $callable


### PR DESCRIPTION
In our fork at WolvesFortress we have introduced fluent setters
This commit also introduces some missing type declarations
~~git diff is a bit messed up since the project was reformatted to use tabs instead of spaces (if wanted, i can add a follow-up PR to undo these)~~
I also suggest getting rid of useless PHPDoc (those that don't add any value) like these: https://github.com/jojoe77777/FormAPI/pull/100/files#diff-cb746c9505f695740c6220a7a3d2bcd8e2620bc9ccc8d3aff51e57890d369d1bR47-L49